### PR TITLE
Fixing splitter regex to not match :first-child and :last-child

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var util = require('util')
 
-var splitter = /^(.*?)(?:\:(eq|first|last)(?:\((\d+)\))?)(.*)/
+var splitter = /^(.*?)(?:\:(eq|(?:(?:first|last)(?!-child)))(?:\((\d+)\))?)(.*)/
 
 exports.wrap = function (Cheerio) {
   var CheerioAdv = function (selector, context, root, opts) {


### PR DESCRIPTION
The splitter regex was matching `:first-child` and `:last-child` resulting in an invalid split.
